### PR TITLE
Port module support features to individual markdown files

### DIFF
--- a/tools/compat/modules/import_meta.md
+++ b/tools/compat/modules/import_meta.md
@@ -1,0 +1,283 @@
+---
+__compat:
+  description: "<code>import.meta</code>"
+  mdn_url: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/import.meta
+  spec_url:
+  - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta
+  - https://vite.dev/guide/env-and-mode
+  - https://webpack.js.org/api/module-variables/#importmeta
+  support:
+    vite:
+      version_added: 1.0.0
+    webpack:
+      version_added: 5.0.0
+    nodejs:
+      version_added: 18.19.0
+    bun:
+      version_added: 1.0.0
+    deno:
+      version_added: 1.28.0
+    esbuild:
+      version_added: 0.18.0
+    rspack:
+      version_added: 1.1.0
+    rsbuild:
+      version_added: 1.1.0
+  status:
+    experimental: false
+    standard_track: true
+    deprecated: false
+url:
+  __compat:
+    description: "<code>import.meta.url</code>"
+    support:
+      vite:
+        version_added: 1.0.0
+      webpack:
+        version_added: 5.0.0
+        notes:
+        - "<code>import.meta.url</code> has <code>file://</code> protocol"
+      nodejs:
+        version_added: 18.19.0
+        notes:
+        - "<code>import.meta.url</code> has <code>file://</code> protocol"
+        - Cannot <code>fetch()</code> the result of <code>import.meta.url</code>
+      bun:
+        version_added: 1.0.0
+        notes:
+        - "<code>import.meta.url</code> has <code>file://</code> protocol"
+      deno:
+        version_added: 1.28.0
+        notes:
+        - "<code>import.meta.url</code> has <code>file://</code> protocol"
+      esbuild:
+        version_added: false
+      rspack:
+        version_added: 1.1.0
+        notes:
+        - "<code>import.meta.url</code> has <code>file://</code> protocol"
+      rsbuild:
+        version_added: 1.1.0
+        notes:
+        - "<code>import.meta.url</code> has <code>file://</code> protocol"
+    status:
+      experimental: false
+      standard_track: true
+      deprecated: false
+  web_worker:
+    __compat:
+      description: "<code>Worker</code> from <code>import.meta.url</code>"
+      mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker#url
+      support:
+        vite:
+          version_added: 1.0.0
+        webpack:
+          version_added: 5.0.0
+        nodejs:
+          version_added: 18.19.0
+          notes:
+          - Using the <code>node:worker_threads</code> API
+          - 'Fails: <code>import.meta.url</code> can load a <code>Worker</code>'
+          partial_implementation: true
+        bun:
+          version_added: 1.1.0
+        deno:
+          version_added: 1.28.0
+        esbuild:
+          version_added: false
+        rspack:
+          version_added: 1.1.0
+        rsbuild:
+          version_added: 1.1.0
+      status:
+        experimental: false
+        standard_track: true
+        deprecated: false
+resolve:
+  __compat:
+    description: "<code>import&#8288;.meta.resolve</code>"
+    support:
+      nodejs:
+        version_added: 18.19.0
+        notes:
+        - Cannot <code>fetch()</code> the result of <code>import.meta.resolve</code>
+      vite:
+        version_added: 5.0.0
+        notes:
+        - Cannot <code>fetch()</code> the result of <code>import.meta.resolve</code>
+      webpack:
+        version_added: false
+      bun:
+      - version_added: 1.1.0
+      - version_added: 1.0.0
+        version_removed: 1.1.0
+        notes:
+        - Cannot <code>fetch()</code> the result of <code>import.meta.resolve</code>
+        - 'Fails: Returns an string'
+        partial_implementation: true
+      deno:
+        version_added: 1.28.0
+      esbuild:
+        version_added: false
+      rsbuild:
+        version_added: false
+      rspack:
+        version_added: false
+    status:
+      experimental: false
+      standard_track: true
+      deprecated: false
+env:
+  __compat:
+    description: "<code>import&#8288;.meta.env</code>"
+    support:
+      vite:
+        version_added: 1.0.0
+      webpack:
+        version_added: false
+      bun:
+        version_added: 1.1.0
+        notes:
+        - 'Fails: <code>import&#8288;.meta.env.{DEV,PROD}</code> exist and are
+          mutually exclusive'
+        - 'Fails: <code>import&#8288;.meta.env.MODE</code> is a string'
+        partial_implementation: true
+      deno:
+        version_added: false
+      esbuild:
+        version_added: false
+      nodejs:
+        version_added: false
+      rsbuild:
+        version_added: 1.1.0
+        notes:
+        - 'Fails: <code>import&#8288;.meta.env</code> is an object'
+        - 'Fails: <code>import&#8288;.meta.env</code> gracefully handles missing
+          values'
+        partial_implementation: true
+      rspack:
+        version_added: false
+    status:
+      experimental: true
+      standard_track: false
+      deprecated: false
+  fallback:
+    __compat:
+      description: "<code>import&#8288;.meta.env?.X</code>"
+      support:
+        esbuild:
+          version_added: 0.18.0
+        rsbuild:
+          version_added: 1.1.0
+        vite:
+          version_added: 5.0.0
+        webpack:
+          version_added: 5.0.0
+        bun:
+          version_added: 1.0.0
+        deno:
+          version_added: 1.28.0
+        nodejs:
+          version_added: 18.19.0
+        rspack:
+          version_added: false
+      status:
+        experimental: true
+        standard_track: false
+        deprecated: false
+hot:
+  __compat:
+    description: "<code>import&#8288;.meta.hot</code>"
+    support:
+      vite:
+        version_added: 1.0.0
+      webpack:
+        version_added: false
+      bun:
+        version_added: false
+      deno:
+        version_added: false
+      esbuild:
+        version_added: false
+      nodejs:
+        version_added: false
+      rsbuild:
+        version_added: false
+      rspack:
+        version_added: false
+    status:
+      experimental: true
+      standard_track: false
+      deprecated: false
+webpack:
+  __compat:
+    description: "<code>import&#8288;.meta.webpack*</code>"
+    support:
+      vite:
+        version_added: false
+      webpack:
+      - version_added: 5.70.0
+      - version_added: 5.0.0
+        version_removed: 5.70.0
+        notes:
+        - 'Fails: <code>import&#8288;.meta.webpackContext</code> is available'
+        partial_implementation: true
+      bun:
+        version_added: false
+      deno:
+        version_added: false
+      esbuild:
+        version_added: false
+      nodejs:
+        version_added: false
+      rsbuild:
+        version_added: 1.1.0
+      rspack:
+        version_added: 1.1.0
+    status:
+      experimental: true
+      standard_track: false
+      deprecated: false
+---
+
+# `import.meta`
+
+## Syntax
+
+### Value
+
+There's two distinct `import.meta` objects: The object that is referenced in source files
+and the object that exists when running the bundle. Since the value is specific to
+individual files, references to `import.meta` are typically replaced during bundling.
+
+For authoring code, bundlers may support the following properties:
+
+<dl>
+  <dt><code>url</code></dt>
+  <dd>A reference to the current module that can be used to reference other resources. Often used in combination with the <code>URL</code> constructor.</dd>
+
+  <dt><code>resolve</code></dt>
+  <dd>Resolves a given specifier in the context of the current file. Very similar to <code>url</code> but more concise for common use cases.</dd>
+
+  <dt><code>hot</code> <ExperimentalInline /></dt>
+  <dd>During development, this may be an object that provides APIs for handling hot replacement. The details of the API are bundler specific.</dd>
+
+  <dt><code>env</code> <ExperimentalInline /></dt>
+  <dd>Object that contains custom environment settings, e.g. those read from <code>.env</code> files.</dd>
+
+  <dt><code>env.DEV</code> and <code>env.PROD</code> <ExperimentalInline /></dt>
+  <dd>
+    <code>env.DEV</code> is a boolean that specifies if development-time debug assertions should be enabled,
+    e.g. because the code is running in an interactive development environment.
+    It's opposite is <code>env.PROD</code> which should always be equal to <code>!env.DEV</code>.
+  </dd>
+
+  <dt><code>env.MODE</code> <ExperimentalInline /></dt>
+  <dd>A string description for a "bundling mode". May include any user-defined string.</dd>
+
+  <dt><code>env.SSR</code> <ExperimentalInline /></dt>
+  <dd>A boolean that is true if the code is running as part of SSR (server-side rendering).</dd>
+
+  <dt><code>webpack</code>, <code>webpackHot</code>, and <code>webpackContext</code> <ExperimentalInline /></dt>
+  <dd>The major version of webpack used to bundle, webpack's hot module replacement API for this module, and contextual information about how this module was included in the current webpack build.</dd>
+</dl>

--- a/tools/compat/modules/resolution/deno.md
+++ b/tools/compat/modules/resolution/deno.md
@@ -1,0 +1,7 @@
+---
+imports:
+  __compat:
+    description: '<code>imports</code> in <code>deno.json</code>'
+---
+
+# `deno.json`

--- a/tools/compat/modules/resolution/fs.md
+++ b/tools/compat/modules/resolution/fs.md
@@ -1,0 +1,7 @@
+---
+realpath:
+  __compat:
+    description: 'realpath affects module identity'
+---
+
+# File System Interactions 

--- a/tools/compat/modules/resolution/glob.md
+++ b/tools/compat/modules/resolution/glob.md
@@ -1,0 +1,13 @@
+---
+pattern_dynamic_import:
+  __compat:
+    description: 'import("./a/" + dyn + ".js")'
+meta_glob:
+  __compat:
+    description: 'import.meta.glob'
+meta_webpack_context:
+  __compat:
+    description: 'import.meta.webpackContext'
+---
+
+# Importing Multiple Possible Files

--- a/tools/compat/modules/resolution/package.exports.md
+++ b/tools/compat/modules/resolution/package.exports.md
@@ -1,0 +1,29 @@
+---
+conditions:
+  custom:
+    __compat:
+      description: 'Configurable conditions'
+  browser:
+    __compat:
+      description: 'browser'
+  dev_prod:
+    __compat:
+      description: 'development/production'
+  runtime_keys:
+    __compat:
+      description: 'Runtime keys (e.g. node)'
+  module:
+    __compat:
+      description: 'module'
+  require_import:
+    __compat:
+      description: 'require / import'
+  module-sync:
+    __compat:
+      description: 'module-sync'
+  node-addons:
+    __compat:
+      description: 'node-addons'
+---
+
+# `exports` (`package.json`)

--- a/tools/compat/modules/resolution/package.md
+++ b/tools/compat/modules/resolution/package.md
@@ -1,0 +1,26 @@
+---
+browser:
+  __compat:
+    description: 'browser field'
+    spec_url:
+      - https://github.com/defunctzombie/package-browser-field-spec
+source:
+  __compat:
+    description: 'source field'
+    spec_url:
+      - https://parceljs.org/features/dependency-resolution/#glob-aliases
+module:
+  __compat:
+    description: 'module field'
+alias:
+  __compat:
+    description: 'alias field'
+imports:
+  __compat:
+    description: 'imports field'
+exports:
+  __compat:
+    description: 'exports field'
+---
+
+# `package.json`

--- a/tools/compat/modules/resolution/scheme.md
+++ b/tools/compat/modules/resolution/scheme.md
@@ -1,0 +1,22 @@
+---
+data:
+  __compat:
+    description: 'Load from <code>data:</code>'
+fs:
+  __compat:
+    description: 'Load from <code>fs:</code>'
+http:
+  __compat:
+    description: 'Load from <code>http:</code>'
+https:
+  __compat:
+    description: 'Load from <code>https:</code>'
+npm:
+  __compat:
+    description: 'Load from <code>npm:</code>'
+node:
+  __compat:
+    description: 'Load from <code>node:</code>'
+---
+
+# Module URL Schemes

--- a/tools/compat/modules/resolution/specifier.md
+++ b/tools/compat/modules/resolution/specifier.md
@@ -1,0 +1,28 @@
+---
+relative_url:
+  __compat:
+    description: '<code>./a%20b</code> (relative URL)'
+relative_path:
+  __compat:
+    description: '<code>./a b</code> (relative FS path)'
+absolute_url:
+  __compat:
+    description: '<code>x://y.z/</code> (absolute URL)'
+absolute_path:
+  __compat:
+    description: '<code>/tmp/a</code> (absolute FS path)'
+tilde:
+  __compat:
+    description: '<code>~</code> (package-relative)'
+self_ref:
+  __compat:
+    description: '<code><name></code> (self-referential)'
+ext_search:
+  __compat:
+    description: 'Automatically adds extensions'
+  identity:
+    __compat:
+      description: 'Extensions are part of module identity'
+---
+
+# Import Specifier

--- a/tools/compat/modules/resolution/tsconfig.md
+++ b/tools/compat/modules/resolution/tsconfig.md
@@ -1,0 +1,7 @@
+---
+imports:
+  __compat:
+    description: '<code>paths</code> in <code>tsconfig.json</code>'
+---
+
+# `tsconfig.json`

--- a/tools/compat/modules/types/bundle.md
+++ b/tools/compat/modules/types/bundle.md
@@ -1,0 +1,7 @@
+---
+bundle_as_string:
+  __compat:
+    description: 'Bundle content as string (e.g. <code>bundle-text:./foo.css</code>)'
+---
+
+# Sub-Bundle Modules

--- a/tools/compat/modules/types/commonjs.md
+++ b/tools/compat/modules/types/commonjs.md
@@ -1,0 +1,22 @@
+---
+cjs_in_esm:
+  __compat:
+    description: 'CommonJS in ESM files'
+require_esm:
+  __compat:
+    description: '<code>require("./x.mjs")</code>'
+exports_object_import_cjs:
+  __compat:
+    description: 'Import the exports object from CommonJS'
+named_import_cjs:
+  __compat:
+    description: 'Detect named imports from CommonJS, e.g. via <code>__esModule</code>'
+import_default_cjs:
+  __compat:
+    description: 'Import the default export from a CommonJS, e.g. via <code>__esModule</code>'
+default_as_namespace:
+  __compat:
+    description: 'Namespace object may be default export, e.g. <code>ns</code> in <code>import * as ns</code> may be a function'
+---
+
+# CommonJS Modules

--- a/tools/compat/modules/types/css.md
+++ b/tools/compat/modules/types/css.md
@@ -1,0 +1,10 @@
+---
+side_effect:
+  __compat:
+    description: 'Side effect import of CSS'
+module_css:
+  __compat:
+    description: 'Import CSS classes (<code>.module.css</code>)'
+---
+
+# CSS Modules

--- a/tools/compat/modules/types/jsx.md
+++ b/tools/compat/modules/types/jsx.md
@@ -1,0 +1,9 @@
+---
+__compat:
+  description: 'Transform JSX expressions'
+inject_imports:
+  __compat:
+    description: 'Inject framework imports'
+---
+
+# JSX Syntax

--- a/tools/compat/modules/types/macro.md
+++ b/tools/compat/modules/types/macro.md
@@ -1,0 +1,7 @@
+---
+compile_time_js:
+  __compat:
+    description: '`type: "macro"'
+---
+
+# Build-Time Modules

--- a/tools/compat/modules/types/raw_file.md
+++ b/tools/compat/modules/types/raw_file.md
@@ -1,0 +1,16 @@
+---
+import_as_blob:
+  __compat:
+    description: 'Import the contents of a file as a Blob'
+import_as_string:
+  __compat:
+    description: 'Import the contents of a file as a string'
+import_as_typed_array:
+  __compat:
+    description: 'Import the contents of a file as a Uint8Array'
+import_as_data_url:
+  __compat:
+    description: 'Import the contents of a <code>data:</code> URL string'
+---
+
+# Raw File Modules

--- a/tools/compat/modules/types/typescript.md
+++ b/tools/compat/modules/types/typescript.md
@@ -1,0 +1,10 @@
+---
+type_stripping:
+  __compat:
+    description: 'Remove type annotations'
+codegen:
+  __compat:
+    description: 'Runtime features like <code>enum</code>'
+---
+
+# TypeScript Modules

--- a/tools/compat/modules/types/worker.md
+++ b/tools/compat/modules/types/worker.md
@@ -1,0 +1,7 @@
+---
+web_worker:
+  __compat:
+    description: 'new WebWorker() turns into entry point'
+---
+
+# Worker Modules


### PR DESCRIPTION
The hope is to be forward-compatible with using the MDN compat schema. That's the reason for assigning ids to the sub features and using the `__compat.description` key.

Most of the files are fairly empty placeholders with basic metadata. `import_meta.md` shows a more fleshed out file that also includes cross-bundler support for the various sub-features.

Ref: https://github.com/mdn/browser-compat-data/blob/main/schemas/compat-data-schema.md

Still missing from https://github.com/tc39/js-outreach-groups/issues/49:

* Runtime APIs (minus `WebWorker`)
* Compilation
* Configuration